### PR TITLE
Add timer utility and Cilkscale API example

### DIFF
--- a/ctimer.h
+++ b/ctimer.h
@@ -406,8 +406,12 @@ void ctimer_stop(
  * Time(<label>) = XX.XXXXXXXXX sec
  * ```
  *
- * @note This utility function is meant to facilitate standardized printing of
- * elapsed times which may then be parsed by external programs.
+ * If `label` is `NULL` or the empty string, the "(<label>)" tag is omitted
+ * from the printed output.
+ *
+ * @note The elapsed time is always printed with 9 decimal digits, although the
+ * system `CLOCK_MONOTONIC`, may have coarser resolution (e.g., microsecond
+ * resolution).
  *
  * @sa ctimer_measure
  * @sa ctimer_lap

--- a/ctimer.h
+++ b/ctimer.h
@@ -1,0 +1,436 @@
+/* -*- c -*- */
+
+/**
+ * [Include-only header library]
+ * C/C++ timer utilities using POSIX `clock_gettime()`.
+ *
+ * @sa <https://github.com/sillycross/mlpds/blob/master/fasttime.h>
+ *
+ * @file        ctimer.h
+ * @version     0.3.0
+ * @author      Alexandros-Stavros Iliopoulos
+ * @license     MIT
+ * @copyright   Copyright (c) 2021 Supertech group, CSAIL, MIT
+ */
+
+
+/******************************************************************************/
+/* MIT License                                                                */
+/*                                                                            */
+/* Copyright (c) 2021 Supertech group, CSAIL, MIT                             */
+/*                                                                            */
+/* Permission is hereby granted, free of charge, to any person obtaining      */
+/* a copy of this software and associated documentation files (the            */
+/* "Software"), to deal in the Software without restriction, including        */
+/* without limitation the rights to use, copy, modify, merge, publish,        */
+/* distribute, sublicense, and/or sell copies of the Software, and to         */
+/* permit persons to whom the Software is furnished to do so, subject to      */
+/* the following conditions:                                                  */
+/*                                                                            */
+/* The above copyright notice and this permission notice shall be             */
+/* included in all copies or substantial portions of the Software.            */
+/*                                                                            */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,            */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF         */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.     */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY       */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,       */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE          */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                     */
+/******************************************************************************/
+
+
+/**
+ * @mainpage
+ *
+ * @section overview Overview
+ *
+ * CTimer is an include-only header library with C/C++ timer utilities using
+ * POSIX `clock_gettime()`.
+ *
+ * Stopwatch utilities:
+ * - `ctimer_t`         :: type of CTimer stopwatch struct
+ * - `ctimer_start()`   :: start stopwatch
+ * - `ctimer_stop()`    :: stop stopwatch
+ * - `ctimer_reset()`   :: reset elapsed time
+ * - `ctimer_measure()` :: measure elapsed time between start & stop
+ * - `ctimer_lap()`     :: accumulate elapsed time between start & stop
+ * - `ctimer_print()`   :: print elapsed time in sec with fixed format
+ *
+ * Timespec struct utilities
+ * - `timespec_sub()`   :: calculate difference between 2 timespecs
+ * - `timespec_add()`   :: calculate sum of 2 timespecs
+ * - `timespec_sec()`   :: timespec tv time in sec (double)
+ * - `timespec_msec()`  :: timespec tv time in msec (long)
+ * - `timespec_usec()`  :: timespec tv time in usec (long)
+ * - `timespec_nsec()`  :: timespec tv time in nsec (long)
+ *
+ * @section usage Using CTimer
+ *
+ * @subsection c_std C standard
+ *
+ * C compilers may require standard `gnu99` or later.  Older compilers may also
+ * require linking with `-lrt`.
+ *
+ * @subsection init Initialization
+ *
+ * There is no guarantee regarding the initial values of timespec fields in a
+ * `ctimer_t` stopwatch.  Querying timespecs that haven't been initialized or
+ * measured may return arbitrary results; this includes measuring the elapsed
+ * time of an unstopped stopwatch.
+ *
+ * The `elapsed` timespec of a `ctimer_t` stopwatch can be reset to 0 using the
+ * `ctimer_reset()` function.  This is not necessary if timings are only
+ * measured using `ctimer_measure()`, but it *is* necessary before using
+ * `ctimer_lap()` with an otherwise un-measured stopwatch.
+ *
+ * @subsection measure_on_stop Automatic elapsed-time measurement on stop
+ *
+ * If the preprocessor macro `CTIMER_MEASURE_ON_STOP` is defined, then
+ * `ctimer_stop()` also calls `ctimer_measure()` internally to calculate and
+ * store the elapsed time in the input `ctimer_t` object.
+ *
+ * @subsection example Example usage in C/C++
+ *
+ * @snippet ctimer_example.c ctimer_example
+ */
+
+
+#ifndef __H_CTIMER__
+#define __H_CTIMER__
+
+
+#include <time.h>
+#include <unistd.h>
+#include <stdio.h>
+
+
+/**
+ * @defgroup ctimer CTimer
+ *
+ * C/C++ timer utilities.
+ *
+ * @{
+ */
+
+
+/* prevent C++ compilers from mangling function names */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* ==================================================
+ * CONSTANTS
+ * ================================================== */
+
+
+/* unit conversion constants */
+#ifdef __cplusplus              /* C++ */
+static const auto _MSEC_PER_SEC = 1000;
+static const auto _USEC_PER_SEC = 1000 * 1000;
+static const auto _NSEC_PER_SEC = 1000 * 1000 * 1000;
+#else  /* C */
+enum {
+_MSEC_PER_SEC = 1000,
+_USEC_PER_SEC = 1000 * 1000,
+_NSEC_PER_SEC = 1000 * 1000 * 1000
+};
+#endif  /* __cplusplus */
+
+
+/* ==================================================
+ * TIMESPEC API
+ * ================================================== */
+
+
+/**
+ * @defgroup ctimer_timespec Timespec API
+ *
+ * Functions for manipulating and inspecting timespec structs.
+ *
+ * @{
+ */
+
+
+/**
+ * Calculate the time difference between two `timespec` structs.  Store time in
+ * sec and nsec in the `tv_sec` and `tv_nsec` field, respectively, of the output
+ * `timespec`.
+ *
+ * @sa https://stackoverflow.com/a/53708448/1036677
+ */
+static inline
+void timespec_sub(
+    struct timespec       * t_diff, /**<[out] time difference */
+    struct timespec const   t_end,  /**<[in]  end time */
+    struct timespec const   t_start /**<[in]  start time */
+) {
+    t_diff->tv_nsec = t_end.tv_nsec - t_start.tv_nsec;
+    t_diff->tv_sec  = t_end.tv_sec  - t_start.tv_sec;
+    if ((t_diff->tv_sec > 0) && (t_diff->tv_nsec < 0)) {
+        t_diff->tv_nsec += _NSEC_PER_SEC;
+        t_diff->tv_sec--;
+    } else if ((t_diff->tv_sec < 0) && (t_diff->tv_nsec > 0)) {
+        t_diff->tv_nsec -= _NSEC_PER_SEC;
+        t_diff->tv_sec++;
+    }
+    /* (s > 0 & ns > 0) : do nothing (t_start < t_end) */
+    /* (s < 0 & ns < 0) : do nothing (t_start > t_end) */
+}
+
+
+/**
+ * Calculate the time sum of two `timespec` structs.  Store time in sec and
+ * nsec in the `tv_sec` and `tv_nsec` field, respectively, of the output
+ * `timespec`.
+ */
+static inline
+void timespec_add(
+    struct timespec       * t_sum, /**<[out] time sum */
+    struct timespec const   t1,    /**<[in]  time 1 */
+    struct timespec const   t2     /**<[in]  time 2 */
+) {
+    t_sum->tv_nsec = t1.tv_nsec + t2.tv_nsec;
+    t_sum->tv_sec  = t1.tv_sec  + t2.tv_sec;
+    if (t_sum->tv_nsec >= _NSEC_PER_SEC) {
+        t_sum->tv_nsec -= _NSEC_PER_SEC;
+        t_sum->tv_sec++;
+    }
+}
+
+
+/**
+ * Return `timespec` time in sec.
+ *
+ * @return (t.tv_sec + t.tv_nsec) in sec
+ */
+static inline
+double timespec_sec(
+    struct timespec const t
+) {
+    return (double)t.tv_sec
+        + (double)t.tv_nsec / _NSEC_PER_SEC;
+}
+
+
+/**
+ * Return `timespec` time in msec.
+ *
+ * @warning Sub-millisecond resolution (if supported by the system clock) is
+ * lost with this function.
+ *
+ * @return (t.tv_sec + t.tv_nsec) in msec
+ */
+static inline
+long timespec_msec(
+    struct timespec const t
+) {
+    return t.tv_sec * _MSEC_PER_SEC
+        + t.tv_nsec / _USEC_PER_SEC;
+}
+
+
+/**
+ * Return `timespec` time in usec.
+ *
+ * @warning Sub-microsecond resolution (if supported by the system clock) is
+ * lost with this function.
+ *
+ * @return (t.tv_sec + t.tv_nsec) in usec
+ */
+static inline
+long timespec_usec(
+    struct timespec const t
+) {
+    return t.tv_sec * _USEC_PER_SEC
+        + t.tv_nsec / _MSEC_PER_SEC;
+}
+
+
+/**
+ * Return `timespec` time in nsec.
+ *
+ * @return (t.tv_sec + t.tv_nsec) in nsec
+ */
+static inline
+long timespec_nsec(
+    struct timespec const t     /**<[in] timespec */
+) {
+    return t.tv_sec * _NSEC_PER_SEC
+        + t.tv_nsec;
+}
+
+
+/** @} */ /* end group ctimer_timespec */
+
+
+/* ==================================================
+ * STOPWATCH API
+ * ================================================== */
+
+
+/**
+ * @defgroup ctimer_stopwatch Stopwatch API
+ *
+ * Functions for manipulating CTimer stopwatches.
+ *
+ * @{
+ */
+
+
+/**
+ * Stopwatch timer struct using `clock_gettime()`.
+ */
+typedef struct {
+    struct timespec tic;        /**< Stopwatch start time  */
+    struct timespec toc;        /**< Stopwatch end time */
+    struct timespec elapsed;    /**< Elapsed/measured time */
+} ctimer_t;
+
+
+/**
+ * Measure elapsed time of `ctimer_t` stopwatch in s+ns and *store* it in the
+ * `elapsed` timer.
+ *
+ * @warning The stopwatch must be started and stopped before the elapsed time
+ * is measured.
+ *
+ * @note It is safe (albeit unnecessary) to measure the elapsed time of a
+ * stopped timer multiple times.
+ *
+ * @note When measuring the cumulative execution time of non-contiguous chunks
+ * of a program (e.g., the total time for a sub-computation of a loop body),
+ * use `ctimer_lap()`.
+ *
+ * @sa ctimer_lap
+ * @sa ctimer_start
+ * @sa ctimer_stop
+ */
+static inline
+void ctimer_measure(
+    ctimer_t * t                /**<[in,out] stopwatch pointer */
+) {
+    timespec_sub( &(t->elapsed), t->toc, t->tic );
+}
+
+
+/**
+ * Measure elapsed time of `ctimer_t` stopwatch in s+ns and *add* it to the
+ * `elapsed` timer.
+ *
+ * @warning The `elapsed` field of the input stopwatch must be properly
+ * initialized (e.g. with `ctimer_reset()`) before calling `ctimer_lap()`.
+ *
+ * @warning The stopwatch must be started and stopped before the elapsed time
+ * is measured.
+ *
+ * @note When measuring the execution time of a single, contiguous chunk of a
+ * program, use `ctimer_measure()`.
+ *
+ * @sa ctimer_reset
+ * @sa ctimer_measure
+ * @sa ctimer_start
+ * @sa ctimer_stop
+ */
+static inline
+void ctimer_lap(
+    ctimer_t * t                /**<[in,out] stopwatch pointer */
+) {
+    /* elapsed += toc - tic */
+    timespec_add( &(t->elapsed), t->elapsed, t->toc );
+    timespec_sub( &(t->elapsed), t->elapsed, t->tic );
+}
+
+
+/**
+ * Zero out the `elapsed` timer of a `ctimer_t` stopwatch.
+ *
+ * @sa ctimer_lap
+ */
+static inline
+void ctimer_reset(
+    ctimer_t * t                /**<[in,out] stopwatch pointer */
+) {
+    t->elapsed = (struct timespec){0};
+}
+
+
+/**
+ * Start a `ctimer_t` stopwatch.  Sets the the `tic` timer of the stopwatch.
+ *
+ * @sa ctimer_stop
+ * @sa ctimer_measure
+ * @sa ctimer_lap
+ */
+static inline
+void ctimer_start(
+    ctimer_t * t                /**<[in,out] stopwatch pointer */
+) {
+    clock_gettime( CLOCK_MONOTONIC, &(t->tic) );
+}
+
+
+/**
+ * Stop a `ctimer_t` stopwatch.  Sets the `toc` timer of the stopwatch.
+ *
+ * @note If the `CTIMER_MEASURE_ON_STOP` preprocessor macro is defined _before_
+ * the `ctimer/ctimer.h` library is included in a program, then `ctimer_stop`
+ * also calculates the elapsed time between `tic` and `toc` and stores it in
+ * the `elapsed` field.
+ *
+ * @sa ctimer_start
+ * @sa ctimer_measure
+ * @sa ctimer_lap
+ */
+static inline
+void ctimer_stop(
+    ctimer_t * t                /**<[in,out] stopwatch pointer */
+) {
+    clock_gettime( CLOCK_MONOTONIC, &(t->toc) );
+#ifdef CTIMER_MEASURE_ON_STOP
+    ctimer_measure( t );
+#endif
+}
+
+
+/**
+ * Print a line with the `elapsed` time of a `ctimer_t` stopwatch in seconds.
+ *
+ * The line is printed as:
+ * ```
+ * Time(<label>) = XX.XXXXXXXXX sec
+ * ```
+ *
+ * @note This utility function is meant to facilitate standardized printing of
+ * elapsed times which may then be parsed by external programs.
+ *
+ * @sa ctimer_measure
+ * @sa ctimer_lap
+ */
+static inline
+void ctimer_print(
+    ctimer_t const * t,         /**<[in] stopwatch pointer */
+    char     const * label      /**<[in] label/description for printed time */
+) {
+    if ((label != NULL) && (label[0] != '\0'))
+        printf( "Time(%s) = ", label );
+    else
+        printf( "Time = " );
+
+    printf( "%ld.%09ld sec\n", (long)t->elapsed.tv_sec, t->elapsed.tv_nsec );
+}
+
+
+/** @} */ /* end group ctimer_stopwatch */
+
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+
+/** @} */ /* end group ctimer */
+
+
+#endif  /* __H_CTIMER__ */

--- a/fib.c
+++ b/fib.c
@@ -3,7 +3,6 @@
 
 #include <cilk/cilk.h>
 
-#define CTIMER_MEASURE_ON_STOP
 #include "ctimer.h"
 
 long fib(long n) {
@@ -26,6 +25,7 @@ int main(int argc, char *argv[]) {
   long result = fib(n);
 
   ctimer_stop(&t);
+  ctimer_measure(&t);
 
   printf("fib(%ld) = %ld\n", n, result);
   ctimer_print(t, "fib");

--- a/fib.c
+++ b/fib.c
@@ -8,9 +8,11 @@
 long fib(long n) {
   if (n < 2)
     return n;
-  long x = cilk_spawn fib(n-1);
-  long y = fib(n-2);
-  cilk_sync;
+  long x, y;
+  cilk_scope {
+    x = cilk_spawn fib(n-1);
+    y = fib(n-2);
+  }
   return x + y;
 }
 

--- a/fib.c
+++ b/fib.c
@@ -3,6 +3,9 @@
 
 #include <cilk/cilk.h>
 
+#define CTIMER_MEASURE_ON_STOP
+#include "ctimer.h"
+
 long fib(long n) {
   if (n < 2)
     return n;
@@ -17,7 +20,14 @@ int main(int argc, char *argv[]) {
   if (argc > 1)
     n = atol(argv[1]);
 
+  ctimer_t t;
+  ctimer_start(&t);
+
   long result = fib(n);
+
+  ctimer_stop(&t);
+
   printf("fib(%ld) = %ld\n", n, result);
+  ctimer_print(&t, "fib");
   return 0;
 }

--- a/fib.c
+++ b/fib.c
@@ -28,6 +28,6 @@ int main(int argc, char *argv[]) {
   ctimer_stop(&t);
 
   printf("fib(%ld) = %ld\n", n, result);
-  ctimer_print(&t, "fib");
+  ctimer_print(t, "fib");
   return 0;
 }

--- a/nqueens.c
+++ b/nqueens.c
@@ -63,12 +63,13 @@ int nqueens (int n, int j, char *a) {
   b = (char *) alloca((j + 1) * sizeof (char));
   memcpy(b, a, j * sizeof (char));
 
-  for (int i = 0; i < n; i++) {
-    b[j] = i;
-    if (ok(j + 1, b))
-      count[i] = cilk_spawn nqueens(n, j + 1, b);
+  cilk_scope {
+    for (int i = 0; i < n; i++) {
+      b[j] = i;
+      if (ok(j + 1, b))
+        count[i] = cilk_spawn nqueens(n, j + 1, b);
+    }
   }
-  cilk_sync;
 
   for (int i = 0; i < n; i++) {
     solNum += count[i];

--- a/nqueens.c
+++ b/nqueens.c
@@ -5,6 +5,8 @@
 
 #include <cilk/cilk.h>
 
+#include "ctimer.h"
+
 unsigned long long todval (struct timeval *tp) {
     return tp->tv_sec * 1000 * 1000 + tp->tv_usec;
 }
@@ -94,14 +96,14 @@ int main(int argc, char *argv[]) {
   a = (char *) alloca (n * sizeof (char));
   res = 0;
 
-  struct timeval t1, t2;
-  gettimeofday(&t1,0);
+  ctimer_t t;
+  ctimer_start(&t);
 
   res = nqueens(n, 0, a);
 
-  gettimeofday(&t2,0);
-  unsigned long long runtime_ms = (todval(&t2)-todval(&t1))/1000;
-  printf("%f\n", runtime_ms/1000.0);
+  ctimer_stop(&t);
+  ctimer_measure(&t);
+  ctimer_print(t);
 
   if (res == 0) {
     fprintf (stderr, "No solution found.\n");

--- a/nqueens.c
+++ b/nqueens.c
@@ -104,7 +104,7 @@ int main(int argc, char *argv[]) {
 
   ctimer_stop(&t);
   ctimer_measure(&t);
-  ctimer_print(t);
+  ctimer_print(t, "nqueens");
 
   if (res == 0) {
     fprintf (stderr, "No solution found.\n");

--- a/qsort.c
+++ b/qsort.c
@@ -13,6 +13,8 @@
 
 #include <cilk/cilk.h>
 
+#include "ctimer.h"
+
 void swap(int* a, int* b) {
   int tmp = *a;
   *a = *b;
@@ -108,7 +110,13 @@ int main(int argc, char **argv) {
     a[i] = rand_r(&seed);
   }
 
+  ctimer_t t;
+  ctimer_start(&t);
+
   sample_qsort(a, a + n);
+
+  ctimer_stop(&t);
+  ctimer_measure(&t);
 
   // Confirm that a is sorted and that each element contains the index.
   failFlag = 0;
@@ -129,6 +137,8 @@ int main(int argc, char **argv) {
   } else {
     printf("%d sorts failed\n", failCount);
   }
+
+  ctimer_print(t, "sample_qsort");
 
   // free integer array
   free(a);

--- a/qsort.c
+++ b/qsort.c
@@ -84,7 +84,7 @@ int main(int argc, char **argv) {
   int failFlag;
 
   // get number of integers to sort, default 1 million
-  int n = 100*100;
+  int n = 1000*1000;
   if (argc > 1) {
     n = atoi(argv[1]);
   }

--- a/qsort.c
+++ b/qsort.c
@@ -56,12 +56,11 @@ void sample_qsort(int* begin, int* end) {
     // move pivot to middle
     swap((end - 1), middle);
 
-    // sort lower partition
-    cilk_spawn sample_qsort(middle+1, end);
-    sample_qsort(begin, middle);
-
-    // sort upper partition (excluding pivot)
-    cilk_sync;
+    // sort in parallel
+    cilk_scope {
+      cilk_spawn sample_qsort(middle+1, end); // sort upper partition w/o pivot
+      sample_qsort(begin, middle); // sort lower partition
+    }
   }
 }
 

--- a/qsort_wsp.c
+++ b/qsort_wsp.c
@@ -14,6 +14,8 @@
 #include <cilk/cilk.h>
 #include <cilk/cilkscale.h>
 
+#include "ctimer.h"
+
 void swap(int* a, int* b) {
   int tmp = *a;
   *a = *b;
@@ -109,12 +111,18 @@ int main(int argc, char **argv) {
     a[i] = rand_r(&seed);
   }
 
+  ctimer_t t;
+  ctimer_start(&t);
+
   wsp_t start, end;
   start = wsp_getworkspan();
 
   sample_qsort(a, a + n);
 
   end = wsp_getworkspan();
+
+  ctimer_stop(&t);
+  ctimer_measure(&t);
 
   // Confirm that a is sorted and that each element contains the index.
   failFlag = 0;
@@ -137,6 +145,7 @@ int main(int argc, char **argv) {
   }
 
   wsp_dump(wsp_sub(end, start), "sample_qsort");
+  ctimer_print(t, "sample_qsort");
 
   // free integer array
   free(a);

--- a/qsort_wsp.c
+++ b/qsort_wsp.c
@@ -57,12 +57,11 @@ void sample_qsort(int* begin, int* end) {
     // move pivot to middle
     swap((end - 1), middle);
 
-    // sort lower partition
-    cilk_spawn sample_qsort(middle+1, end);
-    sample_qsort(begin, middle);
-
-    // sort upper partition (excluding pivot)
-    cilk_sync;
+    // sort in parallel
+    cilk_scope {
+      cilk_spawn sample_qsort(middle+1, end); // sort upper partition w/o pivot
+      sample_qsort(begin, middle); // sort lower partition
+    }
   }
 }
 

--- a/qsort_wsp.c
+++ b/qsort_wsp.c
@@ -85,7 +85,7 @@ int main(int argc, char **argv) {
   int failFlag;
 
   // get number of integers to sort, default 1 million
-  int n = 100*100;
+  int n = 1000*1000;
   if (argc > 1) {
     n = atoi(argv[1]);
   }

--- a/qsort_wsp.c
+++ b/qsort_wsp.c
@@ -143,8 +143,8 @@ int main(int argc, char **argv) {
     printf("%d sorts failed\n", failCount);
   }
 
-  wsp_dump(wsp_sub(end, start), "sample_qsort");
   ctimer_print(t, "sample_qsort");
+  wsp_dump(wsp_sub(end, start), "sample_qsort");
 
   // free integer array
   free(a);

--- a/qsort_wsp.c
+++ b/qsort_wsp.c
@@ -1,0 +1,144 @@
+/*
+ * qsort.c
+ *
+ * Copyright (c) 2007, 2008 Cilk Arts, Inc.  All rights reserved.
+ *
+ * An implementation of quicksort using Cilk parallelization.
+ */
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <cilk/cilk.h>
+#include <cilk/cilkscale.h>
+
+void swap(int* a, int* b) {
+  int tmp = *a;
+  *a = *b;
+  *b = tmp;
+}
+
+// Partition array using last element of array as pivot
+// (move elements less than last to lower partition
+// and elements not less than last to upper partition
+// return middle = the first element not less than last
+int* partition(int* begin, int* end, int pivot) {
+  while (begin < end) {
+    if (*begin < pivot) {
+      begin++;
+    } else {
+      end--;
+      swap(begin, end);
+    }
+  }
+  return end;
+}
+
+
+// Sort the range between pointers begin and end.
+// end is one past the final element in the range.
+// Use the Quick Sort algorithm, using recursive divide and conquer.
+void sample_qsort(int* begin, int* end) {
+  if (begin < end) {
+    // get last element
+    int last = *(end - 1);
+
+    // we give partition a pointer to the first element and one past the last element
+    // of the range we want to partition
+    // move all values which are >= last to the end
+    // move all value which are < last to the beginning
+    // return a pointer to the first element >= last
+    int * middle = partition(begin, end - 1, last);
+
+    // move pivot to middle
+    swap((end - 1), middle);
+
+    // sort lower partition
+    cilk_spawn sample_qsort(middle+1, end);
+    sample_qsort(begin, middle);
+
+    // sort upper partition (excluding pivot)
+    cilk_sync;
+  }
+}
+
+void print_array(const int *a, size_t n) {
+  assert(a > 0);
+  printf("a: (%d", a[0]);
+  int i;
+  for (i = 1; i < n; ++i) {
+    printf(", %d", a[i]);
+  }
+  printf(")\n");
+}
+
+// A simple test harness.  Program takes 2 optional arguments:
+//   First argument specifies the length of the array to sort.
+//   Defaults to 10 thousand.
+//   Second argument specifies the number of trials to run.
+//   Defaults to 1.
+int main(int argc, char **argv) {
+  int *a = NULL, failCount = 0;
+  int failFlag;
+
+  // get number of integers to sort, default 1 million
+  int n = 100*100;
+  if (argc > 1) {
+    n = atoi(argv[1]);
+  }
+  printf("Sorting %d integers\n", n);
+
+  // check arguments
+  if (n < 1) {
+    printf("array length must be positive\n");
+    exit(-1);
+  }
+
+  // allocate memory for array
+  a = (int *) malloc(sizeof(int)*n);
+  if (!a) {
+    printf("array allocation failed\n");
+    exit(-1);
+  }
+
+  // initialize to pseudorandom inputs
+  unsigned int seed = 13;
+  for (int i = 0; i < n; ++i) {
+    a[i] = rand_r(&seed);
+  }
+
+  wsp_t start, end;
+  start = wsp_getworkspan();
+
+  sample_qsort(a, a + n);
+
+  end = wsp_getworkspan();
+
+  // Confirm that a is sorted and that each element contains the index.
+  failFlag = 0;
+  for (int i = 1; i < n; ++i) {
+    if (a[i] < a[i-1]) {
+#ifdef DEBUG
+      printf("Sort failed at location i = %d: a[i-1] = %d, a[i] = %d\n", i, a[i-1], a[i]);
+#endif
+      failFlag = 1;
+    }
+  }
+  if (failFlag == 1) {
+    ++failCount;
+  }
+
+  if (failCount == 0) {
+    printf("All sorts succeeded\n");
+  } else {
+    printf("%d sorts failed\n", failCount);
+  }
+
+  wsp_dump(wsp_sub(end, start), "sample_qsort");
+
+  // free integer array
+  free(a);
+  return failCount;
+}


### PR DESCRIPTION
This PR makes the following additions to bring the OpenCilk tutorials repo in sync with the [OpenCilk Getting Started
page](https://www.opencilk.org/doc/users-guide/getting-started/).

1. Add a simple C/C++ timer utility ([ctimer](https://github.com/ailiop/ctimer)).
2. Time the `fib()` execution and print the result.
3. Add example of using the Cilkscale API with `qsort` program.

Addresses issue [#172 (website repo)](https://github.com/OpenCilk/www.opencilk.org/issues/172).